### PR TITLE
Define version in pyproject.toml instead of source code

### DIFF
--- a/marimo_labs/__init__.py
+++ b/marimo_labs/__init__.py
@@ -1,5 +1,12 @@
-__version__ = "0.1.0"
-
-__all__ = ["huggingface"]
+import importlib.metadata
+import warnings
 
 import marimo_labs.huggingface as huggingface
+
+try:
+    __version__ = importlib.metadata.version(__name__)
+except importlib.metadata.PackageNotFoundError as e:
+    warnings.warn(f"Could not determine version of {__name__}\n{e!r}", stacklevel=2)
+    __version__ = "unknown"
+
+__all__ = ["huggingface"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "marimo_labs"
 description = "Cutting-edge experimental features for marimo"
-dynamic = ["version"]
+version = "0.1.0"
 dependencies = [
     "marimo>=0.3.8",
     "huggingface_hub>=0.19.3",
@@ -45,9 +45,6 @@ dev = [
     "typos~=1.20.4",
     "pytest~=8.1.1",
 ]
-
-[tool.setuptools.dynamic]
-version = { attr = "marimo_labs.__version__" }
 
 [tool.setuptools.packages.find]
 # project source is entirely contained in the `marimo` package


### PR DESCRIPTION
How about defining your version in `pyproject.toml` with all of your other package metadata instead of the source code? @akshayka 